### PR TITLE
Ensure Swagger example works with valid invoice payload

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from fastapi import FastAPI, HTTPException, Response
+from fastapi import Body, FastAPI, HTTPException, Response
 
-from .models import Invoice
+from .models import INVOICE_EXAMPLE, Invoice
 from .utils import generate_facturx_pdf
 
 app = FastAPI(
@@ -19,7 +19,11 @@ def ping() -> dict[str, str]:
 
 
 @app.post("/invoices/pdf", response_class=Response)
-def create_invoice_pdf(invoice: Invoice) -> Response:
+def create_invoice_pdf(
+    invoice: Invoice = Body(
+        ..., examples={"ValidInvoice": {"summary": "Invoice conforme", "value": INVOICE_EXAMPLE}}
+    )
+) -> Response:
     try:
         pdf_bytes = generate_facturx_pdf(invoice)
     except ValueError as exc:  # pragma: no cover - defensive

--- a/app/models.py
+++ b/app/models.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class Address(BaseModel):
@@ -36,14 +36,64 @@ class LineItem(BaseModel):
         return value
 
 
+INVOICE_EXAMPLE: Dict[str, Any] = {
+    "invoice_number": "INV-2024-0001",
+    "issue_date": "2024-01-15",
+    "due_date": "2024-01-30",
+    "currency": "EUR",
+    "payment_reference": "INV-2024-0001",
+    "payment_means_code": "30",
+    "seller_bank_iban": "FR7630004000031234567890143",
+    "seller": {
+        "name": "ACME Corp",
+        "address": {
+            "street": "1 Infinite Loop",
+            "postal_code": "75001",
+            "city": "Paris",
+            "country_code": "FR",
+        },
+        "vat_identifier": "FR12345678901",
+        "tax_registration_id": "123456789",
+        "email": "billing@acme.example",
+    },
+    "buyer": {
+        "name": "Client SAS",
+        "address": {
+            "street": "10 Rue de la Paix",
+            "postal_code": "75002",
+            "city": "Paris",
+            "country_code": "FR",
+        },
+        "vat_identifier": "FR98765432109",
+        "email": "contact@client.example",
+    },
+    "line_items": [
+        {
+            "description": "Consulting services",
+            "quantity": "2",
+            "unit_price": "150",
+            "vat_rate": "20",
+        },
+        {
+            "description": "Software license",
+            "quantity": "1",
+            "unit_price": "300",
+            "vat_rate": "20",
+        },
+    ],
+}
+
+
 class Invoice(BaseModel):
+    model_config = ConfigDict(json_schema_extra={"example": INVOICE_EXAMPLE})
+
     invoice_number: str = Field(..., min_length=1)
     issue_date: date
     due_date: Optional[date] = None
     seller: Party
     buyer: Party
     currency: str = Field(default="EUR", min_length=3, max_length=3)
-    line_items: List[LineItem] = Field(default_factory=list)
+    line_items: List[LineItem] = Field(..., min_length=1)
     payment_reference: Optional[str] = None
     payment_means_code: str = Field(default="30")
     seller_bank_iban: Optional[str] = None
@@ -55,17 +105,10 @@ class Invoice(BaseModel):
             return value.replace(" ", "")
         return value
 
-    @field_validator("line_items")
-    @classmethod
-    def _ensure_lines(cls, value):
-        if not value:
-            raise ValueError("Invoice must contain at least one line item")
-        return value
-
-
 __all__ = [
     "Address",
     "Party",
     "LineItem",
     "Invoice",
+    "INVOICE_EXAMPLE",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pypdf>=5.3.0
 lxml
 fastapi
 uvicorn
+httpx
 reportlab
 pydantic>=2.0
 pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,59 +8,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from facturx import get_facturx_xml_from_pdf, xml_check_xsd
 from fastapi.testclient import TestClient
 
+from copy import deepcopy
+
 from app.main import app
+from app.models import INVOICE_EXAMPLE
 
 
 client = TestClient(app)
 
 
 def test_generate_invoice_pdf():
-    payload = {
-        "invoice_number": "INV-2024-0001",
-        "issue_date": "2024-01-15",
-        "due_date": "2024-01-30",
-        "currency": "EUR",
-        "payment_reference": "INV-2024-0001",
-        "payment_means_code": "30",
-        "seller_bank_iban": "FR7630004000031234567890143",
-        "seller": {
-            "name": "ACME Corp",
-            "address": {
-                "street": "1 Infinite Loop",
-                "postal_code": "75001",
-                "city": "Paris",
-                "country_code": "FR",
-            },
-            "vat_identifier": "FR12345678901",
-            "tax_registration_id": "123456789",
-            "email": "billing@acme.example",
-        },
-        "buyer": {
-            "name": "Client SAS",
-            "address": {
-                "street": "10 Rue de la Paix",
-                "postal_code": "75002",
-                "city": "Paris",
-                "country_code": "FR",
-            },
-            "vat_identifier": "FR98765432109",
-            "email": "contact@client.example",
-        },
-        "line_items": [
-            {
-                "description": "Consulting services",
-                "quantity": "2",
-                "unit_price": "150",
-                "vat_rate": "20",
-            },
-            {
-                "description": "Software license",
-                "quantity": "1",
-                "unit_price": "300",
-                "vat_rate": "20",
-            },
-        ],
-    }
+    payload = deepcopy(INVOICE_EXAMPLE)
 
     response = client.post("/invoices/pdf", json=payload)
 


### PR DESCRIPTION
## Summary
- share a single reusable invoice example for the schema, tests and documentation
- require at least one line item and surface the example directly in the /invoices/pdf body
- declare the httpx dependency required by FastAPI's TestClient

## Testing
- `pytest` *(fails: missing httpx dependency because installing packages is blocked by the execution environment proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68de9f5fb0248323826743d57f77d08c